### PR TITLE
Jb routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6942,6 +6942,28 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+      "requires": {
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^2.2.0",
+        "value-equal": "^0.4.0",
+        "warning": "^3.0.0"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -6956,6 +6978,11 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "hoist-non-react-statics": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -12645,6 +12672,48 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
       "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA=="
     },
+    "react-router": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "requires": {
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.1",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
+      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "requires": {
+        "history": "^4.7.2",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.1",
+        "react-router": "^4.3.1",
+        "warning": "^4.0.1"
+      }
+    },
     "react-scripts": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-2.1.5.tgz",
@@ -13305,6 +13374,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+    },
+    "resolve-pathname": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
+      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -15153,6 +15227,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "value-equal": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
+      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -15214,6 +15293,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watch": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
+    "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.5"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,40 +1,12 @@
 import React, { Component } from 'react';
-import APIManager from './modules/APIManager';
-import Employee from './components/employee/employee-component'
+import ApplicationViews from './components/ApplicationViews'
 
 
 export default class App extends Component {
 
-  state = {
-    employees: [],
-    departments: [],
-    computers: [],
-    trainingPrograms: [],
-    customers: [],
-    products: [],
-    orders: [],
-    paymentTypes: [],
-    productTypes: []
-  }
-
-  getAll = (resource) => {
-    APIManager.getAll(resource)
-      .then(data => this.setState({ [resource]: data }))
-  }
-
-
-  render() {
-
-    return (
-      <React.Fragment>
-        <h1>Bangazon!</h1>
-        <Employee getAll={this.getAll} employees={this.state.employees} />
-      </React.Fragment>
+  render(){
+    return(
+      <ApplicationViews />
     )
-
-
   }
-
-
-
 }

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,4 +1,4 @@
-import { Route, Redirect } from 'react-router-dom'
+import { Route } from 'react-router-dom'
 import React, { Component } from "react"
 import Employee from './employee/employee-component'
 import APIManager from '../modules/APIManager';
@@ -31,35 +31,29 @@ class ApplicationViews extends Component {
           return <Employee getAll={this.getAll} employees={this.state.employees} />
         }} />
         <Route exact path="/departments" render={(props) => {
-          return <p>Departments</p>
+          return <h1>Departments</h1>
         }} />
         <Route exact path="/training-programs" render={(props) => {
-          return <p>Training Programs</p>
+          return <h1>Training Programs</h1>
         }} />
         <Route exact path="/computers" render={(props) => {
-          return <p>Computers</p>
+          return <h1>Computers</h1>
         }} />
         <Route exact path="/customers" render={(props) => {
-          return <p>Customers</p>
+          return <h1>Customers</h1>
         }} />
         <Route exact path="/orders" render={(props) => {
-          return <p>Order</p>
+          return <h1>Order</h1>
         }} />
         <Route exact path="/payment-types" render={(props) => {
-          return <p>Payment Types</p>
+          return <h1>Payment Types</h1>
         }} />
         <Route exact path="/products" render={(props) => {
-          return <p>Products</p>
+          return <h1>Products</h1>
         }} />
         <Route exact path="/product-types" render={(props) => {
-          return <p>Product Types</p>
+          return <h1>Product Types</h1>
         }} />
-
-
-
-
-
-
       </React.Fragment>
     )
   }

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -1,0 +1,68 @@
+import { Route, Redirect } from 'react-router-dom'
+import React, { Component } from "react"
+import Employee from './employee/employee-component'
+import APIManager from '../modules/APIManager';
+
+
+class ApplicationViews extends Component {
+
+  state = {
+    employees: [],
+    departments: [],
+    computers: [],
+    trainingPrograms: [],
+    customers: [],
+    products: [],
+    orders: [],
+    paymentTypes: [],
+    productTypes: []
+  }
+
+  getAll = (resource) => {
+    APIManager.getAll(resource)
+      .then(data => this.setState({ [resource]: data }))
+  }
+
+  render() {
+
+    return (
+      <React.Fragment>
+        <Route exact path="/employees" render={(props) => {
+          return <Employee getAll={this.getAll} employees={this.state.employees} />
+        }} />
+        <Route exact path="/departments" render={(props) => {
+          return <p>Departments</p>
+        }} />
+        <Route exact path="/training-programs" render={(props) => {
+          return <p>Training Programs</p>
+        }} />
+        <Route exact path="/computers" render={(props) => {
+          return <p>Computers</p>
+        }} />
+        <Route exact path="/customers" render={(props) => {
+          return <p>Customers</p>
+        }} />
+        <Route exact path="/orders" render={(props) => {
+          return <p>Order</p>
+        }} />
+        <Route exact path="/payment-types" render={(props) => {
+          return <p>Payment Types</p>
+        }} />
+        <Route exact path="/products" render={(props) => {
+          return <p>Products</p>
+        }} />
+        <Route exact path="/product-types" render={(props) => {
+          return <p>Product Types</p>
+        }} />
+
+
+
+
+
+
+      </React.Fragment>
+    )
+  }
+}
+
+export default ApplicationViews

--- a/src/components/employee/employee-component/index.js
+++ b/src/components/employee/employee-component/index.js
@@ -6,15 +6,10 @@ class Employee extends Component {
     this.props.getAll('employees')
   }
 
-  consoleLog = () => {
-    console.log(this.props.employees)
-  }
-
   render() {
     return (
       <div>
-        <button onClick={this.consoleLog}>Console Log</button>
-        <p>Employees!</p>
+        <h1>Employees</h1>
         <ul>
           {
             this.props.employees.map(employee => {

--- a/src/components/employee/employee-component/index.js
+++ b/src/components/employee/employee-component/index.js
@@ -10,7 +10,6 @@ class Employee extends Component {
     console.log(this.props.employees)
   }
 
-
   render() {
     return (
       <div>
@@ -31,7 +30,6 @@ class Employee extends Component {
       </div>
     )
   }
-
 
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
+import { BrowserRouter as Router } from "react-router-dom"
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+  <Router>
+    <App />
+  </Router>, document.getElementById('root')
+);
+
+
 

--- a/src/modules/APIManager.js
+++ b/src/modules/APIManager.js
@@ -11,7 +11,7 @@ class APIManager {
     .catch(err => console.log("oops!", err))
   }
 
-  getSingle = (resource, id, apiUrl, stateToSet) => {
+  getSingle = (resource, id, stateToSet) => {
     let url = `${apiUrl}${resource}/${id}`
     fetch(url)
     .then(response => response.json())


### PR DESCRIPTION
Set up the routes for each general resource. For now there is just an H1 tag with the name of the resource. You can swap this out for your components once you merge. This involved creating an ApplicationViews.js component. All the logic that was in App.js was moved down to ApplicationViews. App.js now renders ApplicationViews. Index.js renders the router and app.

To test it you will need to     npm install --save react-router-dom
Visit each of these routes below and make sure you can see the corresponding H1 tag. Employees will have a list of employees and their start date from my last ticket.

http://localhost:3000/employees
http://localhost:3000/departments
http://localhost:3000/training-programs
http://localhost:3000/computers
http://localhost:3000/products
http://localhost:3000/customers
http://localhost:3000/orders
http://localhost:3000/payment-types
http://localhost:3000/product-types